### PR TITLE
Enable custom application version

### DIFF
--- a/log4net.Raygun.Core/IRaygunMessageBuilder.cs
+++ b/log4net.Raygun.Core/IRaygunMessageBuilder.cs
@@ -8,6 +8,7 @@ namespace log4net.Raygun.Core
     public interface IRaygunMessageBuilder
     {
 		RaygunMessage BuildMessage(Exception exception, LoggingEvent loggingEvent, Dictionary<string, string> userCustomData,
-			IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredFieldSettings ignoredFieldSettings);
+			IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredFieldSettings ignoredFieldSettings, 
+            string customApplicationVersion);
     }
 }

--- a/log4net.Raygun.Core/RaygunAppenderBase.cs
+++ b/log4net.Raygun.Core/RaygunAppenderBase.cs
@@ -60,6 +60,8 @@ namespace log4net.Raygun.Core
         public virtual string ExceptionFilter { get; set; }
         public virtual string RenderedMessageFilter { get; set; }
 
+        public virtual string ApplicationVersion { get; set; }
+
         protected override void Append(LoggingEvent loggingEvent)
         {
             LogLog.Debug(DeclaringType, string.Format("RaygunAppender: Received Logging Event with Logging Level '{0}'", loggingEvent.Level));
@@ -119,7 +121,7 @@ namespace log4net.Raygun.Core
 			var ignoredFieldSettings = new IgnoredFieldSettings(IgnoredFormNames, IgnoredHeaderNames, IgnoredCookieNames, IgnoredServerVariableNames);
 
             RaygunMessage raygunMessage = _raygunMessageBuilder.BuildMessage(exception, loggingEvent, userCustomData,
-				exceptionFilter, renderedMessageFilter, ignoredFieldSettings);
+				exceptionFilter, renderedMessageFilter, ignoredFieldSettings, ApplicationVersion);
 
             return raygunMessage;
         }

--- a/log4net.Raygun.WebApi/RaygunWebApiMessageBuilder.cs
+++ b/log4net.Raygun.WebApi/RaygunWebApiMessageBuilder.cs
@@ -16,11 +16,9 @@ namespace log4net.Raygun.WebApi
         public static readonly Type DeclaringType = typeof(RaygunAppenderBase);
 
         public RaygunMessage BuildMessage(Exception exception, LoggingEvent loggingEvent, Dictionary<string, string> userCustomData,
-            IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredFieldSettings ignoredFieldSettings)
+            IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredFieldSettings ignoredFieldSettings,
+            string customApplicationVersion)
         {
-            LogLog.Debug(DeclaringType, "RaygunAppender: Resolving application assembly");
-            var assemblyResolver = new AssemblyResolver();
-            var applicationAssembly = assemblyResolver.GetApplicationAssembly();
             var raygunMessageBuilder = Mindscape.Raygun4Net.WebApi.RaygunWebApiMessageBuilder.New;
 
             var httpRequestMessage = ResolveHttpRequestMessageFromLog4NetProperties(loggingEvent.Properties);
@@ -40,7 +38,7 @@ namespace log4net.Raygun.WebApi
                 .SetTags(ExtractTags(loggingEvent.Properties))
                 .SetEnvironmentDetails()
                 .SetMachineName(Environment.MachineName)
-                .SetVersion(applicationAssembly != null ? applicationAssembly.GetName().Version.ToString() : null)
+                .SetVersion(GetApplicationVersion(customApplicationVersion))
                 .SetUserCustomData(FilterRenderedMessageInUserCustomData(userCustomData, renderedMessageFilter));
 
             var raygunMessage = raygunMessageBuilder.Build();
@@ -63,6 +61,20 @@ namespace log4net.Raygun.WebApi
             }
 
             return raygunMessage;
+        }
+
+        private string GetApplicationVersion(string customApplicationVersion)
+        {
+            if (!string.IsNullOrEmpty(customApplicationVersion))
+            {
+                LogLog.Debug(DeclaringType, "RaygunAppender: Using custom applicationversion " + customApplicationVersion);
+                return customApplicationVersion;
+            }
+
+            LogLog.Debug(DeclaringType, "RaygunAppender: Resolving application assembly");
+            var assemblyResolver = new AssemblyResolver();
+            var applicationAssembly = assemblyResolver.GetApplicationAssembly();
+            return applicationAssembly != null ? applicationAssembly.GetName().Version.ToString() : null;
         }
 
         private IList<string> ExtractTags(ReadOnlyPropertiesDictionary loggingEventProperties)

--- a/log4net.Raygun.WebApi/log4net.Raygun.WebApi.csproj
+++ b/log4net.Raygun.WebApi/log4net.Raygun.WebApi.csproj
@@ -97,7 +97,7 @@
     <RemoveDir Directories="NuGet" />
     <MakeDir Directories="NuGet" />
     <!-- Package the project -->
-    <Exec WorkingDirectory="$(BuildDir)" Command="$(ProjectDir)\..\.nuget\NuGet.exe pack log4net.Raygun.WebApi.nuspec -Verbosity detailed -Symbols -OutputDir &quot;NuGet&quot; -Version %(OutputAssemblyInfo.Version) -Properties &quot;Configuration=$(Configuration)&quot;" />
+    <Exec WorkingDirectory="$(BuildDir)" Command="&quot;$(ProjectDir)\..\.nuget\NuGet.exe&quot; pack log4net.Raygun.WebApi.nuspec -Verbosity detailed -Symbols -OutputDir &quot;NuGet&quot; -Version %(OutputAssemblyInfo.Version) -Properties &quot;Configuration=$(Configuration)&quot;" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/log4net.Raygun/log4net.Raygun.csproj
+++ b/log4net.Raygun/log4net.Raygun.csproj
@@ -99,8 +99,8 @@
     <RemoveDir Directories="NuGet" />
     <MakeDir Directories="NuGet" />
     <!-- Package the project -->
-    <Exec WorkingDirectory="$(BuildDir)" Command="$(ProjectDir)\..\.nuget\NuGet.exe pack log4net.Raygun.nuspec -Verbosity detailed -Symbols -OutputDir &quot;NuGet&quot; -Version %(OutputAssemblyInfo.Version) -Properties &quot;Configuration=$(Configuration)&quot;" />
-    <Exec WorkingDirectory="$(BuildDir)" Command="$(ProjectDir)\..\.nuget\NuGet.exe pack log4net.Raygun.Mvc.nuspec  -Verbosity detailed -Symbols -OutputDir &quot;NuGet&quot; -Version %(OutputAssemblyInfo.Version) -Properties &quot;Configuration=$(Configuration)&quot;" />
+    <Exec WorkingDirectory="$(BuildDir)" Command="&quot;$(ProjectDir)\..\.nuget\NuGet.exe&quot; pack log4net.Raygun.nuspec -Verbosity detailed -Symbols -OutputDir &quot;NuGet&quot; -Version %(OutputAssemblyInfo.Version) -Properties &quot;Configuration=$(Configuration)&quot;" />
+    <Exec WorkingDirectory="$(BuildDir)" Command="&quot;$(ProjectDir)\..\.nuget\NuGet.exe&quot; pack log4net.Raygun.Mvc.nuspec  -Verbosity detailed -Symbols -OutputDir &quot;NuGet&quot; -Version %(OutputAssemblyInfo.Version) -Properties &quot;Configuration=$(Configuration)&quot;" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Previous behaviour is kept as default.

If element `<applicationVersion value="0.0.1" />` is added to appender config, application version is overridden.

Needed this for an interop project where assembly version was not available (and in other cases not the one used)

(slightly related: MindscapeHQ/raygun4net#254)