### PR TITLE
Can omit raw data from raygun messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following configuration properties can be used to omit sensitive data from b
 * `ignoredHeaderNames` (optional) : Comma delimited list of header field names to omit when logging details of an Http Request.
 * `ignoredCookieNames` (optional) : Comma delimited list of cookie field names to omit when logging details of an Http Request.
 * `ignoredServerVariableNames` (optional) : Comma delimited list of server variable field names to omit when logging details of an Http Request.
+* `isRawDataIgnored` (optional) : Set to true if you do not want the raw request content to be included in the message sent to Raygun.
 
 A log4net `threshold` should be used to filter out logging levels (e.g. everything below ERROR level). By default, all levels of logging will be sent to Raygun.
 

--- a/log4net.Raygun.Core/IRaygunMessageBuilder.cs
+++ b/log4net.Raygun.Core/IRaygunMessageBuilder.cs
@@ -8,6 +8,6 @@ namespace log4net.Raygun.Core
     public interface IRaygunMessageBuilder
     {
 		RaygunMessage BuildMessage(Exception exception, LoggingEvent loggingEvent, Dictionary<string, string> userCustomData,
-			IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredFieldSettings ignoredFieldSettings);
+			IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredDataSettings ignoredFieldSettings);
     }
 }

--- a/log4net.Raygun.Core/IgnoredDataSettings.cs
+++ b/log4net.Raygun.Core/IgnoredDataSettings.cs
@@ -3,14 +3,16 @@ using System.Linq;
 
 namespace log4net.Raygun.Core
 {
-	public sealed class IgnoredFieldSettings
+	public sealed class IgnoredDataSettings
 	{
-		public IgnoredFieldSettings(string ignoredFormNames = null, string ignoredHeaderNames = null, string ignoredCookieNames = null, string ignoredServerVariableNames = null)
+		public IgnoredDataSettings(string ignoredFormNames = null, string ignoredHeaderNames = null,
+            string ignoredCookieNames = null, string ignoredServerVariableNames = null, bool isRawDataIgnored = false)
 		{
 			IgnoredFormNames = SplitIgnoredSetting(ignoredFormNames);
 			IgnoredHeaderNames = SplitIgnoredSetting(ignoredHeaderNames);
 			IgnoredCookieNames = SplitIgnoredSetting(ignoredCookieNames);
 			IgnoredServerVariableNames = SplitIgnoredSetting(ignoredServerVariableNames);
+            IsRawDataIgnored = isRawDataIgnored;
 		}
 
 		private IEnumerable<string> SplitIgnoredSetting(string setting) 
@@ -25,6 +27,8 @@ namespace log4net.Raygun.Core
 		public IEnumerable<string> IgnoredCookieNames { get; private set; }
 
 		public IEnumerable<string> IgnoredServerVariableNames { get; private set; }
+
+        public bool IsRawDataIgnored { get; private set; }
 	}
 }
 

--- a/log4net.Raygun.Core/RaygunAppenderBase.cs
+++ b/log4net.Raygun.Core/RaygunAppenderBase.cs
@@ -46,6 +46,7 @@ namespace log4net.Raygun.Core
         }
 
         public virtual bool OnlySendExceptions { get; set; }
+        // Analysis disable once ConvertToAutoProperty
         public virtual bool SendInBackground
         {
             get { return _sendInBackground; }
@@ -56,6 +57,7 @@ namespace log4net.Raygun.Core
 		public virtual string IgnoredHeaderNames { get; set; }
 		public virtual string IgnoredCookieNames { get; set; }
 		public virtual string IgnoredServerVariableNames { get; set; }
+        public virtual bool IsRawDataIgnored { get; set; }
 
         public virtual string ExceptionFilter { get; set; }
         public virtual string RenderedMessageFilter { get; set; }
@@ -116,7 +118,8 @@ namespace log4net.Raygun.Core
 
             var exceptionFilter = ActivateInstanceOfMessageFilter(ExceptionFilter);
             var renderedMessageFilter = ActivateInstanceOfMessageFilter(RenderedMessageFilter);
-			var ignoredFieldSettings = new IgnoredFieldSettings(IgnoredFormNames, IgnoredHeaderNames, IgnoredCookieNames, IgnoredServerVariableNames);
+            var ignoredFieldSettings = new IgnoredDataSettings(IgnoredFormNames, IgnoredHeaderNames, 
+                IgnoredCookieNames, IgnoredServerVariableNames, IsRawDataIgnored);
 
             RaygunMessage raygunMessage = _raygunMessageBuilder.BuildMessage(exception, loggingEvent, userCustomData,
 				exceptionFilter, renderedMessageFilter, ignoredFieldSettings);

--- a/log4net.Raygun.Core/log4net.Raygun.Core.csproj
+++ b/log4net.Raygun.Core/log4net.Raygun.Core.csproj
@@ -67,7 +67,7 @@
     <Compile Include="AssemblyAdapter.cs" />
     <Compile Include="IAssembly.cs" />
     <Compile Include="UserCustomDataBuilderExtensions.cs" />
-    <Compile Include="IgnoredFieldSettings.cs" />
+    <Compile Include="IgnoredDataSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/log4net.Raygun.WebApi/RaygunWebApiMessageBuilder.cs
+++ b/log4net.Raygun.WebApi/RaygunWebApiMessageBuilder.cs
@@ -16,7 +16,7 @@ namespace log4net.Raygun.WebApi
         public static readonly Type DeclaringType = typeof(RaygunAppenderBase);
 
         public RaygunMessage BuildMessage(Exception exception, LoggingEvent loggingEvent, Dictionary<string, string> userCustomData,
-            IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredFieldSettings ignoredFieldSettings)
+            IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredDataSettings ignoredFieldSettings)
         {
             LogLog.Debug(DeclaringType, "RaygunAppender: Resolving application assembly");
             var assemblyResolver = new AssemblyResolver();
@@ -30,6 +30,8 @@ namespace log4net.Raygun.WebApi
 
                 var messageOptions = new RaygunRequestMessageOptions(ignoredFieldSettings.IgnoredFormNames, ignoredFieldSettings.IgnoredHeaderNames,
                     ignoredFieldSettings.IgnoredCookieNames, ignoredFieldSettings.IgnoredServerVariableNames);
+
+                messageOptions.IsRawDataIgnored = ignoredFieldSettings.IsRawDataIgnored;
 
                 raygunMessageBuilder.SetHttpDetails(httpRequestMessage, messageOptions);
             }

--- a/log4net.Raygun/RaygunMessageBuilder.cs
+++ b/log4net.Raygun/RaygunMessageBuilder.cs
@@ -22,7 +22,7 @@ namespace log4net.Raygun
         }
 
         public RaygunMessage BuildMessage(Exception exception, LoggingEvent loggingEvent, Dictionary<string, string> userCustomData,
-            IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredFieldSettings ignoredFieldSettings)
+            IMessageFilter exceptionFilter, IMessageFilter renderedMessageFilter, IgnoredDataSettings ignoredFieldSettings)
         {
             LogLog.Debug(DeclaringType, "RaygunAppender: Resolving application assembly");
             var assemblyResolver = new AssemblyResolver();
@@ -36,6 +36,8 @@ namespace log4net.Raygun
 
                 var messageOptions = new RaygunRequestMessageOptions(ignoredFieldSettings.IgnoredFormNames, ignoredFieldSettings.IgnoredHeaderNames,
                     ignoredFieldSettings.IgnoredCookieNames, ignoredFieldSettings.IgnoredServerVariableNames);
+
+                messageOptions.IsRawDataIgnored = ignoredFieldSettings.IsRawDataIgnored;
 
                 raygunMessageBuilder.SetHttpDetails(httpContext.Instance, messageOptions);
             }


### PR DESCRIPTION
Raygun4Net by default includes the raw requests received (headers + body) in the error messages it sends to raygun.io, and includes a configuration option to turn this off (in case there is sensitive information). This feature is to expose that configuration option through log4net.raygun.